### PR TITLE
Add signal handling/fix deadlock/enable or disable stdin handling

### DIFF
--- a/cmds/termhook/main.go
+++ b/cmds/termhook/main.go
@@ -35,7 +35,7 @@ func main() {
 		}
 	}
 
-	hook, err := termhook.NewHook(port, speed, nil)
+	hook, err := termhook.NewHook(port, speed, false, nil)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Fix handling signals
Fix deadlock in reading from errCh channel
Make it possible to specify whether we should handle stdin
Minor code style changes: use lower-case characters for type Hook